### PR TITLE
chore: changed link to stars shield

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![License](https://img.shields.io/github/license/Tenderly/node-extensions-library)](./LICENSE)
 [![Twitter](https://img.shields.io/twitter/follow/TenderlyApp?style=social)](https://twitter.com/intent/follow?screen_name=TenderlyApp)
-[![Github](https://img.shields.io/github/stars/Tenderly/node-extensions-library?style=social)](https://github.com/Tenderly/node-extensions-library)
+[![Github](https://img.shields.io/github/stars/Tenderly/node-extensions-library?style=social)](https://github.com/Tenderly/node-extensions-library/stargazers)
 
 </div>
 


### PR DESCRIPTION
This PR updates the GitHub stars shield link in the README.md file. The previous link was outdated or misconfigured. The new link ensures the badge accurately reflects the star count for this repository (Tenderly).


## Checklist

- [ ] My changes don't generate any warnings or lint errors
- [ ] I have performed a self-review of my own code

## QA

Steps to reproduce the behavior:

1. ...
2. ...
